### PR TITLE
chore: rename GITHUB_PAT to GH_TOKEN

### DIFF
--- a/home/claude-code.nix
+++ b/home/claude-code.nix
@@ -13,7 +13,7 @@
         type = "http";
         url = "https://api.githubcopilot.com/mcp";
         headers = {
-          Authorization = "Bearer \${GITHUB_PAT}";
+          Authorization = "Bearer \${GH_TOKEN}";
         };
       };
     };

--- a/home/shell.nix
+++ b/home/shell.nix
@@ -31,7 +31,7 @@
       {
         VOLTA_HOME = "$HOME/.volta";
         CONTEXT7_API_KEY = "$(cat ${config.home.homeDirectory}/.config/opnix/context7)";
-        GITHUB_PAT = "$(cat ${config.home.homeDirectory}/.config/opnix/github)";
+        GH_TOKEN = "$(cat ${config.home.homeDirectory}/.config/opnix/github)";
       }
       // (lib.optionalAttrs (profile == "personal") {
         JAVA_HOME = "/Library/Java/JavaVirtualMachines/zulu-17.jdk/Contents/Home";

--- a/home/vscode.nix
+++ b/home/vscode.nix
@@ -117,7 +117,7 @@
             type = "http";
             url = "https://api.githubcopilot.com/mcp";
             headers = {
-              Authorization = "Bearer \${env:GITHUB_PAT}";
+              Authorization = "Bearer \${env:GH_TOKEN}";
             };
           };
         };


### PR DESCRIPTION
Rename the `GITHUB_PAT` env var to `GH_TOKEN` to match the conventional name used by the GitHub CLI / tooling ecosystem.

Renames the declaration in `home/shell.nix` and updates the two consumers (GitHub MCP server in `home/vscode.nix` and `home/claude-code.nix`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)